### PR TITLE
Don't jpeg compress images that were not orginally jpeg compressed, as i...

### DIFF
--- a/src/gui/painting/qprintengine.h
+++ b/src/gui/painting/qprintengine.h
@@ -93,6 +93,7 @@ public:
         PPK_UseCompression = 0xfe10,
         PPK_ImageQuality,
         PPK_ImageDPI,
+        PPK_ForceJPEG,
 
         PPK_CustomBase = 0xff00
     };

--- a/src/gui/painting/qprintengine_pdf_p.h
+++ b/src/gui/painting/qprintengine_pdf_p.h
@@ -165,6 +165,8 @@ public:
         }
     };
     
+    bool forceJpeg;
+
     OutlineItem *outlineRoot;
     OutlineItem *outlineCurrent;
     void writeOutlineChildren(OutlineItem *node);
@@ -188,7 +190,7 @@ public:
 
     void convertImage(const QImage & image, QByteArray & imageData);
 
-    int addImage(const QImage &image, bool *bitmap, qint64 serial_no, const QImage * noneScaled=0, const QByteArray * data=0, bool * useScaled=0);
+    int addImage(const QImage &image, bool *bitmap, qint64 serial_no, const QImage * noneScaled=0, const QByteArray * orgData=0, bool * useScaled=0);
     int addConstantAlphaObject(int brushAlpha, int penAlpha = 255);
     int addBrushPattern(const QTransform &matrix, bool *specifyColor, int *gStateObject);
 
@@ -219,7 +221,8 @@ private:
     int imageQuality;
 
     int writeImage(const QByteArray &data, int width, int height, int depth,
-                   int maskObject, int softMaskObject, bool dct = false);
+                   int maskObject, int softMaskObject, bool dct = false,
+                   bool isDeflated = false, bool isPredicted = false);
     void writePage();
 
     int addXrefEntry(int object, bool printostr = true);


### PR DESCRIPTION
...t generally causes non-photography images to have very visible artifacts.
Add property to override this behaviour.

Change the behaviour of imageDPI such that we can set it to 0 to prevent the rescaling of images (that is, 0 is interpreted as infinity).

Don't waste time compressing the same data several times.
Don't make decisions on which kind of compression to use on the compressed image data by compressing the original data.
Fix invalid pdf files being generated in rare degenerate cases where the compressed version of the scaled image is larger than the compressed version of the unscaled data.
Don't limit the size of jpeg compressed images to 1MB.
Prepare for supporting deflated images with predictor (PNG style compression).
