### PR TITLE
Fix dpi

### DIFF
--- a/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
+++ b/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
@@ -223,8 +223,8 @@ QWebPrinterPrivate::QWebPrinterPrivate(const QWebFrame *f, QPaintDevice *printer
     , frame(f)
     , graphicsContext(&p)
 {
-    const qreal zoomFactorX = printer->logicalDpiX() / qt_defaultDpi();
-    const qreal zoomFactorY = printer->logicalDpiY() / qt_defaultDpi();
+    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / (qreal)qt_defaultDpi();
+    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / (qreal)qt_defaultDpi();
     IntRect pageRect(0, 0,
                      int(printer->width() / zoomFactorX),
                      int(printer->height() / zoomFactorY));

--- a/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
+++ b/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
@@ -223,8 +223,8 @@ QWebPrinterPrivate::QWebPrinterPrivate(const QWebFrame *f, QPaintDevice *printer
     , frame(f)
     , graphicsContext(&p)
 {
-    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / (qreal)qt_defaultDpi();
-    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / (qreal)qt_defaultDpi();
+    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / (qreal)96;
+    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / (qreal)96;
     IntRect pageRect(0, 0,
                      int(printer->width() / zoomFactorX),
                      int(printer->height() / zoomFactorY));


### PR DESCRIPTION
This fixes two DPI-related bugs. The first fixes the different output scale that resulted when using different values for --dpi (due to using integer division instead of floating point division). The second fix ensures that the system DPI setting does not affect the output (due to webkit using a fixed DPI of 96 instead of the system DPI, see commit message for details).

For the second commit, I'm not sure whether hardcoding 96 there is the best solution, maybe it should include CSSHelper.h and use the constant defined in there instead. There also might be other places where qt_defaultDpi should be replaced with 96.

After these fixes, the output is consistent on Ubuntu 14.4 and Windows 8.1 regardless of the --dpi value and regardless of the windows "Make text and other items larger or smaller" setting (I tried 100%/96dpi and 150%/144dpi). My test results are in http://we.tl/PqVEjlo47g . The only difference I see is that a different font is used on windows and linux.

I also noticed that in my test case the bottom and right border should be 1mm while they are shown slightly larger. That doesn't seem to be related to these changes though (and it doesn't really bother me ;) ).
