### PR TITLE
Cocoa: Remove references to CMProfileRef and related APIs

### DIFF
--- a/src/gui/painting/qpaintengine_mac.cpp
+++ b/src/gui/painting/qpaintengine_mac.cpp
@@ -341,13 +341,7 @@ CGColorSpaceRef QCoreGraphicsPaintEngine::macDisplayColorSpace(const QWidget *wi
 
     // Get the color space from the display profile.
     CGColorSpaceRef colorSpace = 0;
-    CMProfileRef displayProfile = 0;
-    CMError err = CMGetProfileByAVID((CMDisplayIDType)displayID, &displayProfile);
-    if (err == noErr) {
-        colorSpace = CGColorSpaceCreateWithPlatformColorSpace(displayProfile);
-        CMCloseProfile(displayProfile);
-    }
-
+    colorSpace = CGDisplayCopyColorSpace(displayID);
     // Fallback: use generic DeviceRGB
     if (colorSpace == 0)
         colorSpace = CGColorSpaceCreateDeviceRGB();


### PR DESCRIPTION
Deprecated since 10.6.

Reference:
https://gitlab.com/pteam/pteam-qtbase/commit/b06304e164ba47351fa292662c1e6383c081b5ca

The original PR: https://github.com/wkhtmltopdf/qt/pull/19 
