### PR TITLE
Segfault fixed. Crash in RenderBlock::removeFloatingObjectsBelow()

### DIFF
--- a/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
+++ b/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
@@ -3234,6 +3234,8 @@ void RenderBlock::removeFloatingObjectsBelow(FloatingObject* lastFloat, int logi
         floatingObjectSet.removeLast();
         ASSERT(!curr->m_originatingLine);
         delete curr;
+        if (floatingObjectSet.isEmpty())
+            break;
         curr = floatingObjectSet.last();
     }
 }


### PR DESCRIPTION
wkhtmltopdf issue:
wkhtmltopdf/wkhtmltopdf#2684

upstream report:
https://bugs.webkit.org/show_bug.cgi?id=68550

upstream fix:
https://trac.webkit.org/changeset/95654
