### PR TITLE
Added ARGB32_Premultiplied format support

### DIFF
--- a/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/gui/painting/qprintengine_pdf.cpp
@@ -745,6 +745,14 @@ void QPdfEnginePrivate::convertImage(const QImage & image, QByteArray & imageDat
                 *(data++) = qGray(*rgb);
                 ++rgb;
             }
+        } else if (image.format() == QImage::Format_ARGB32_Premultiplied) {
+            for (int x = 0; x < w; ++x) {
+                double multiplier = (qAlpha(*rgb) / 255.0) == 0 ? 0 : 1.0 / (qAlpha(*rgb) / 255.0);
+                *(data++) = qRed(*rgb) * multiplier;
+                *(data++) = qGreen(*rgb) * multiplier;
+                *(data++) = qBlue(*rgb) * multiplier;
+                ++rgb;
+            }
         } else {
             for (int x = 0; x < w; ++x) {
                 *(data++) = qRed(*rgb);
@@ -856,7 +864,9 @@ int QPdfEnginePrivate::addImage(const QImage &img, bool *bitmap, qint64 serial_n
             image = image.convertToFormat(QImage::Format_Mono);
     } else {
         *bitmap = false;
-        if (image.format() != QImage::Format_RGB32 && image.format() != QImage::Format_ARGB32)
+        if (image.format() != QImage::Format_RGB32
+            && image.format() != QImage::Format_ARGB32
+            && image.format() != QImage::Format_ARGB32_Premultiplied)
             image = image.convertToFormat(QImage::Format_ARGB32);
     }
     QImage::Format format = image.format();


### PR DESCRIPTION
In the case when original image comes to our code in format
ARGB32_Premultiplied we convert it to format ARGB32. The conversion
constructs new QImage object and allocates buffer for it. Conversion will
be done for scaled and nonScaled QImage objects.
If we support ARGB32_Premultiplied two unnecessary allocations will be
skipped saving us a lot memory. Ex.:
In test fail.html mentioned in wkhtmltopdf/wkhtmltopdf#2684 i saw that
large nonScaled QImage consums memory amount about 300mb (8000px x 10000px
4-byte ARGB32_Premultiplied). And when we convert it into ARGB32 it
allocates another ~ 300mb of memory for new QImage object.
But we can work with that format wothout conversion.
