### PR TITLE
Calculate requiredHeight based on tallest cell

### DIFF
--- a/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
@@ -514,6 +514,8 @@ int RenderTableSection::layoutRows(int toAdd, int headHeight, int footHeight)
             int remainingLogicalHeight = pageLogicalHeight - layoutState->pageLogicalOffset(m_rowPos[r]) % pageLogicalHeight;
             int availableHeight = remainingLogicalHeight - footHeight - vspacing;
             RenderTableRow* rowRenderer = m_grid[r].rowRenderer;
+            
+            int rowRequiredHeight = 0;
 
             for (int c = 0; c < nEffCols; c++) {
                 CellStruct& cs = cellAt(r, c);
@@ -523,13 +525,15 @@ int RenderTableSection::layoutRows(int toAdd, int headHeight, int footHeight)
                     continue;
 
                 int cellRequiredHeight = cell->contentLogicalHeight() + cell->paddingTop(false) + cell->paddingBottom(false);
-                int requiredHeight = max(logicalRowHeights[r], cellRequiredHeight);
-                if (requiredHeight >= availableHeight && requiredHeight < pageLogicalHeight) {
-                    pageOffset += remainingLogicalHeight + headHeight;
-                    if (requiredHeight > availableHeight) {
-                        m_rowPos[r] += remainingLogicalHeight + headHeight;
-                    }
-                    break;
+                if( cellRequiredHeight > rowRequiredHeight ){
+                    rowRequiredHeight = cellRequiredHeight;
+                }
+            }
+            int requiredHeight = max(logicalRowHeights[r], rowRequiredHeight);
+            if (requiredHeight >= availableHeight && requiredHeight < pageLogicalHeight) {
+                pageOffset += remainingLogicalHeight + headHeight;
+                if (requiredHeight > availableHeight) {
+                    m_rowPos[r] += remainingLogicalHeight + headHeight;
                 }
             }
         }


### PR DESCRIPTION
Previously the `requiredHeight` for the row was set to the height of the first cell found in the row. If another cell happened to want to push the row height taller, the row height was not correctly calculated and it appeared the row would fit on the current page. Once we get to rendering, the row _doesn't_ fit on the current page and flips itself to the next page -- without the headHeight adjustment to the row position. The THEAD then prints itself over the top of that row.

The processing time here will take longer as we now need to determine the `contentLogicalHeight` for every cell rather than just the first, but there's no way around that.
