### PR TITLE
Avoid segfault on pages with ChartJS canvas. Fixes  #3242

### DIFF
--- a/src/3rdparty/webkit/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
+++ b/src/3rdparty/webkit/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
@@ -181,7 +181,9 @@ JSValue JSCanvasRenderingContext2D::setLineDash(ExecState* exec)
         JSValue v = array->get(exec, i);
         lineDash.append(v.toNumber(exec));
     }
-    context->setLineDash(lineDash, lineDash[0]);
+    if (length > 0 ) {
+        context->setLineDash(lineDash, lineDash[0]);
+    }
     return jsUndefined();
 }
 


### PR DESCRIPTION
I am not sure if this is the proper fix, but it seems to work for me.