### PR TITLE
Support CSS "page-break-before" avoid and always for table rows

### DIFF
--- a/src/3rdparty/webkit/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
+++ b/src/3rdparty/webkit/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
@@ -181,7 +181,9 @@ JSValue JSCanvasRenderingContext2D::setLineDash(ExecState* exec)
         JSValue v = array->get(exec, i);
         lineDash.append(v.toNumber(exec));
     }
-    context->setLineDash(lineDash, lineDash[0]);
+    if (length > 0) {
+        context->setLineDash(lineDash, lineDash[0]);
+    }
     return jsUndefined();
 }
 


### PR DESCRIPTION
This was requested multiple times, e.g. https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2997 and https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3395.

This code adds support for 'avoid' and 'always' options of 'page-break-before' property for table rows.

Always is usually used when you just need to break the table at the particular position.

Avoid is used when your table has some sort of row groups which you wouldn't want to be broken to the next page in the middle of. In that case you can set 'auto' for the first row in a group and 'avoid' for all the others - then the page will only be broken between the groups.

PS: An algorithm is just looking for the previous row we can break before. If there is no such row - we're in trouble, meaning that there's nothing we can do to support 'avoid' property.