### PR TITLE
Applying the font spaces fix used in the official qt but with escaped spaces

### DIFF
--- a/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/gui/painting/qprintengine_pdf.cpp
@@ -1364,6 +1364,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
     int toUnicode = requestObject();
 
     QFontEngine::Properties properties = font->fontEngine->properties();
+    QByteArray postscriptName = properties.postscriptName.replace(' ', '_');
 
     {
         qreal scale = 1000/properties.emSquare.toReal();
@@ -1377,7 +1378,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
             s << (char)('A' + (tag % 26));
             tag /= 26;
         }
-        s <<  '+' << properties.postscriptName << "\n"
+        s <<  '+' << postscriptName << "\n"
             "/Flags " << 4 << "\n"
             "/FontBBox ["
           << properties.boundingBox.x()*scale
@@ -1420,7 +1421,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
         QPdf::ByteStream s(&cid);
         s << "<< /Type /Font\n"
             "/Subtype /CIDFontType2\n"
-            "/BaseFont /" << properties.postscriptName << "\n"
+            "/BaseFont /" << postscriptName << "\n"
             "/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >>\n"
             "/FontDescriptor " << fontDescriptor << "0 R\n"
             "/CIDToGIDMap /Identity\n"
@@ -1444,7 +1445,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
         QPdf::ByteStream s(&font);
         s << "<< /Type /Font\n"
             "/Subtype /Type0\n"
-            "/BaseFont /" << properties.postscriptName << "\n"
+            "/BaseFont /" << postscriptName << "\n"
             "/Encoding /Identity-H\n"
             "/DescendantFonts [" << cidfont << "0 R]\n"
             "/ToUnicode " << toUnicode << "0 R"
@@ -1688,7 +1689,7 @@ void QPdfEnginePrivate::printString(const QString &string) {
     // (0xfeff), with the high-order byte first.
     QByteArray array("(\xfe\xff");
     const ushort *utf16 = string.utf16();
-    
+
     for (int i=0; i < string.size(); ++i) {
         char part[2] = {char((*(utf16 + i)) >> 8), char((*(utf16 + i)) & 0xff)};
         for(int j=0; j < 2; ++j) {

--- a/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/gui/painting/qprintengine_pdf.cpp
@@ -1364,7 +1364,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
     int toUnicode = requestObject();
 
     QFontEngine::Properties properties = font->fontEngine->properties();
-    QByteArray postscriptName = properties.postscriptName.replace(' ', '_');
+    QByteArray postscriptName = properties.postscriptName.replace(' ', '#20');
 
     {
         qreal scale = 1000/properties.emSquare.toReal();

--- a/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/gui/painting/qprintengine_pdf.cpp
@@ -1364,7 +1364,7 @@ void QPdfEnginePrivate::embedFont(QFontSubset *font)
     int toUnicode = requestObject();
 
     QFontEngine::Properties properties = font->fontEngine->properties();
-    QByteArray postscriptName = properties.postscriptName.replace(' ', '#20');
+    QByteArray postscriptName = properties.postscriptName.replace(" ", "#20");
 
     {
         qreal scale = 1000/properties.emSquare.toReal();


### PR DESCRIPTION
From this PR => https://codereview.qt-project.org/#/c/154801/
That however replaces strings with underscores which is technically changing the font name.
This PR changes the unescaped spaces to escaped ones (`#20`)
Therefore I created this PR along with one for the official solution: https://github.com/wkhtmltopdf/qt/pull/38
You may decide what you like better.

Full disclosure: I did not test this solution, but I believe it works just like in the official qt repository.

This closes #37, closes wkhtmltopdf/wkhtmltopdf#3857, and closes wkhtmltopdf/wkhtmltopdf#3672