### PR TITLE
Avoid "QFont::setPixelSize: Pixel size <= 0 (0)"

### DIFF
--- a/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformDataQt.cpp
+++ b/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformDataQt.cpp
@@ -45,7 +45,8 @@ FontPlatformData::FontPlatformData(const FontDescription& description, const Ato
     QFont& font = m_data->font;
     int requestedSize = qRound(description.computedPixelSize());
     font.setFamily(familyName);
-    font.setPixelSize(qRound(requestedSize));
+    if (qRound(requestedSize))
+        font.setPixelSize(qRound(requestedSize));
     font.setItalic(description.italic());
     font.setWeight(toQFontWeight(description.weight()));
     font.setWordSpacing(wordSpacing);


### PR DESCRIPTION
As discussed on https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2124

Applies modified patch from webkit
https://bugs.webkit.org/show_bug.cgi?id=114175