### PR TITLE
Repairs the construction of CMap objects so that the mapping order …

### DIFF
--- a/src/gui/text/qfontsubset.cpp
+++ b/src/gui/text/qfontsubset.cpp
@@ -538,6 +538,32 @@ int QFontSubset::addGlyph(int index)
     return idx;
 }
 
+int QFontSubset::addGlyph(int index, int& new_index, int begin)
+{
+    int idx = glyph_indices.indexOf(index);
+    new_index = glyph_indices.indexOf(index);
+    if (idx < 0) {
+        idx = glyph_indices.size();
+        glyph_indices.append(index);
+        if (begin==1) {
+            qSort(glyph_indices.begin(), glyph_indices.end());
+        }
+        else {
+            if (begin<(glyph_indices.size()-1)) {
+                QList<int> aid;
+                for (int i=begin;i<glyph_indices.size();i++) {
+                     aid.append(glyph_indices.at(i));
+                }
+                qSort(aid.begin(), aid.end());
+                for (int i=0;i<aid.size();i++) {
+                     glyph_indices[begin+i] = aid.at(i);
+                }
+            }
+        }
+        new_index = glyph_indices.indexOf(index);
+    }
+    return idx;
+}
 
 // ------------------------------ Truetype generation ----------------------------------------------
 

--- a/src/gui/text/qfontsubset_p.h
+++ b/src/gui/text/qfontsubset_p.h
@@ -63,8 +63,8 @@ class QFontSubset
 {
 public:
     QFontSubset(QFontEngine *fe, int obj_id = 0)
-        : object_id(obj_id), noEmbed(false), fontEngine(fe), downloaded_glyphs(0), standard_font(false)
-        { fontEngine->ref.ref(); addGlyph(0); }
+        : new_index(0), object_id(obj_id), noEmbed(false), fontEngine(fe), downloaded_glyphs(0), standard_font(false)
+        { fontEngine->ref.ref(); addGlyph(0); addGlyph(0,new_index,1);}
     ~QFontSubset() {
         if (!fontEngine->ref.deref() && fontEngine->cache_count == 0)
             delete fontEngine;
@@ -80,7 +80,9 @@ public:
 
     static QByteArray glyphName(unsigned short unicode, bool symbol);
 
+    int new_index;
     int addGlyph(int index);
+	int addGlyph(int index, int& new_index, int begin);
     const int object_id;
     bool noEmbed;
     QFontEngine *fontEngine;


### PR DESCRIPTION
…doesn’t reflect the character order of the text. This is a vulnerability reported on this link: https://www.cyber.gov.au/publications/redaction-functionality-in-adobe-acrobat-pro

The change applied to the code inserts a reordering of the CMap object values, in ascending order, for each page created.