### PR TITLE
Fix format of outline destinations

### DIFF
--- a/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/gui/painting/qprintengine_pdf.cpp
@@ -1522,8 +1522,8 @@ void QPdfEngine::addAnchor(const QRectF &r, const QString &name)
     char buf[256];
     QRectF rr = d->pageMatrix().mapRect(r);
     uint anchor = d->addXrefEntry(-1);
-    d->xprintf("[%d /XYZ %s \n",
-               d->pages.size() - 1,
+    d->xprintf("[%d 0 R /XYZ %s \n",
+               d->pages.back(),
                qt_real_to_string(rr.left(), buf));
     d->xprintf("%s 0]\n",
                qt_real_to_string(rr.bottom(), buf));


### PR DESCRIPTION
The first item of a destination should be a pointer to a page, not a
page number. See PDF Reference 1.7 Section 12.3.2.

Fixes https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3275